### PR TITLE
Add `rake tags` rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'awesome_print'
 require 'securerandom'
 require_relative './tasks/code'
 require_relative './tasks/html'
+require_relative './tasks/tags'
 
 AwesomePrint.defaults = {
   indent: 2,

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'awesome_print'
 require 'securerandom'
 require_relative './tasks/code'
 require_relative './tasks/html'
-require_relative './tasks/tags'
+require_relative './tasks/code_start_points'
 
 AwesomePrint.defaults = {
   indent: 2,

--- a/content/bdd-with-cucumber/09/09.05/script.js.adoc
+++ b/content/bdd-with-cucumber/09/09.05/script.js.adoc
@@ -18,27 +18,27 @@ Now we can cut and paste those steps from the existing `steps.js` file into this
 include::../code/js/10-extract-shout-steps/features/step_definitions/shout_steps.js[lines=2..44]
 ----
 
-And run Cucumber shot::[] to check everything's still working. Great.
+And run Cucumber shot::[3] to check everything's still working. Great.
 
 Breaking apart your step definitions into multiple files is more of an art than a science, but we can give you a couple of pieces of advice. We've seen teams try to organise their step definitions by feature so that, for example, the premium accounts feature would have its own steps file. We find that tends to work out badly, since while feature files live in the problem domain, step definitions are closer to the solution domain. Usually multiple features will need to carry out common actions against the system (think of logging in, for example), so this leaves us with low cohesion: step definitions that sit together in the same file, but don't have much in common with each other.
 
 We find it's better to organise your steps by which part of the system they act on. This is a bit hard to illustrate in a tiny solution like Shouty, but bear this in mind when you're working on your own projects.
 
-We could continue to move code from our step definitions into the support layer. For example, we could write a support method for generating messages of a certain length shot::[1, "Highlight lines 20-21"], 
+We could continue to move code from our step definitions into the support layer. For example, we could write a support method for generating messages of a certain length shot::[4, "Highlight lines 20-21"], 
 
 [source,javascript]
 ----
 include::../code/js/10-extract-shout-steps/features/step_definitions/shout_steps.js[lines=18..24]
 ----
 
-or a method for asserting that a person has heard certain messages. shot::[1, "Highlight lines 23-24"]
+or a method for asserting that a person has heard certain messages. shot::[5, "Highlight lines 23-24"]
 
 [source,javascript]
 ----
 include::../code/js/10-extract-shout-steps/features/step_definitions/steps.js[lines=20..26]
 ----
 
-Ideally, each step definition shot::[3] should only contain one or two lines that delegate to your support code.
+Ideally, each step definition shot::[6] should only contain one or two lines that delegate to your support code.
 
 [source,javascript]
 ----

--- a/content/bdd-with-cucumber/09/09.05/script.ruby.adoc
+++ b/content/bdd-with-cucumber/09/09.05/script.ruby.adoc
@@ -13,27 +13,27 @@ Now we can cut and paste those steps from the existing `steps.rb` file into this
 include::../code/ruby/10-extract-shout-steps/features/step_definitions/shout_steps.rb[]
 ----
 
-And run Cucumber shot::[] to check everything's still working. Great.
+And run Cucumber shot::[3] to check everything's still working. Great.
 
 Breaking apart your step definitions into multiple files is more of an art than a science, but we can give you a couple of pieces of advice. We've seen teams try to organise their step definitions by feature so that, for example, the premium accounts feature would have its own steps file. We find that tends to work out badly, since while feature files live in the problem domain, step definitions are closer to the solution domain. Usually multiple features will need to carry out common actions against the system (think of logging in, for example), so this leaves us with low cohesion: step definitions that sit together in the same file, but don't have much in common with each other.
 
 We find it's better to organise your steps by which part of the system they act on. This is a bit hard to illustrate in a tiny solution like Shouty, but bear this in mind when you're working on your own projects.
 
-We could continue to move code from our step definitions into the support layer. For example, we could write a support method for generating messages of a certain length shot::[1, "Highlight lines 15-16"], 
+We could continue to move code from our step definitions into the support layer. For example, we could write a support method for generating messages of a certain length shot::[4, "Highlight lines 15-16"], 
 
 [source,ruby]
 ----
 include::../code/ruby/10-extract-shout-steps/features/step_definitions/shout_steps.rb[lines=13..19]
 ----
 
-or a method for asserting that a person has heard certain messages. shot::[1, "Highlight lines 22-24"]
+or a method for asserting that a person has heard certain messages. shot::[5, "Highlight lines 22-24"]
 
 [source,ruby]
 ----
 include::../code/ruby/10-extract-shout-steps/features/step_definitions/steps.rb[lines=21..25]
 ----
 
-Ideally, each step definition shot::[3] should only contain one or two lines that delegate to your support code. 
+Ideally, each step definition shot::[6] should only contain one or two lines that delegate to your support code. 
 
 [source,ruby]
 ----

--- a/tasks/code_start_points.rb
+++ b/tasks/code_start_points.rb
@@ -1,0 +1,10 @@
+task :code_start_points do
+  system("git fetch")
+  refs = `git ls-remote --heads origin | grep refs/heads/code. | grep -v .start$`.lines.map { |line| line.split(" ").last.strip }
+  push_instructions = refs.map do |branch_ref|
+    start_point_ref = "#{branch_ref}.start"
+    first_commit=`git rev-list --max-parents=0 #{branch_ref.gsub("refs/heads", "refs/remotes/origin")}`.strip
+    "#{first_commit}:#{start_point_ref}"
+  end
+  system("git push --force origin #{push_instructions.join(" ")}")
+end

--- a/tasks/tags.rb
+++ b/tasks/tags.rb
@@ -1,9 +1,0 @@
-task :tags do
-  refs = `git ls-remote --heads origin | grep refs/heads/code.`.lines.map { |line| line.split(" ").last.strip }
-  push_instructions = refs.map do |branch_ref|
-    tag_ref = "#{branch_ref.gsub("refs/heads/", "refs/tags/")}.start"
-    first_commit=`git rev-list --max-parents=0 #{branch_ref}`.strip
-    "#{first_commit}:#{tag_ref}"
-  end
-  system("git push origin #{push_instructions.join(" ")}")
-end

--- a/tasks/tags.rb
+++ b/tasks/tags.rb
@@ -1,0 +1,9 @@
+task :tags do
+  refs = `git ls-remote --heads origin | grep refs/heads/code.`.lines.map { |line| line.split(" ").last.strip }
+  push_instructions = refs.map do |branch_ref|
+    tag_ref = "#{branch_ref.gsub("refs/heads/", "refs/tags/")}.start"
+    first_commit=`git rev-list --max-parents=0 #{branch_ref}`.strip
+    "#{first_commit}:#{tag_ref}"
+  end
+  system("git push origin #{push_instructions.join(" ")}")
+end


### PR DESCRIPTION
This task lists each of the code branch refs in this repo, then find the first commit in each branch, then pushes a tag named `<branch-name>.start`

This then means we could instruct people to clone the code for the beginning of each chapter with:

```
git clone --single-branch --branch code.bdd-with-cucumber.$CHAPTER.$LANGUAGE git@github.com:cucumber-school/scripts code.bdd-with-cucumber.$CHAPTER.$LANGUAGE
```

At the moment we'll have to remember to run the rake task manually to update these tags after we add or rebase a code branch. I guess we could integrate it with the `rake code` task somehow but that's too much for my head in this session.